### PR TITLE
Mitigate malicious initiator ddos

### DIFF
--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -17,9 +17,14 @@ import (
 
 // request limits
 const (
-	generalLimit = 5000
-	routeLimit   = 500
-	timePeriod   = time.Minute
+	generalLimit          = 5000
+	initRouteLimit        = 100
+	resignRouteLimit      = 100
+	reshareRouteLimit     = 100
+	dkgRouteLimit         = 500
+	healthCheckRouteLimit = 500
+	resultsRouteLimit     = 100
+	timePeriod            = time.Minute
 )
 
 // Server structure for operator to store http server and DKG ceremony instances

--- a/pkgs/operator/router.go
+++ b/pkgs/operator/router.go
@@ -12,12 +12,12 @@ import (
 func RegisterRoutes(s *Server) {
 	s.Router.Use(rateLimit(s.Logger, generalLimit))
 
-	addRoute(s.Router, "POST", "/init", s.initHandler, rateLimit(s.Logger, routeLimit))
-	addRoute(s.Router, "POST", "/dkg", s.dkgHandler, rateLimit(s.Logger, routeLimit))
-	addRoute(s.Router, "GET", "/health_check", s.healthHandler, rateLimit(s.Logger, routeLimit))
-	addRoute(s.Router, "POST", "/results", s.resultsHandler, rateLimit(s.Logger, routeLimit))
-	addRoute(s.Router, "POST", "/resign", s.resignHandler, rateLimit(s.Logger, routeLimit))
-	addRoute(s.Router, "POST", "/reshare", s.reshareHandler, rateLimit(s.Logger, routeLimit))
+	addRoute(s.Router, "POST", "/init", s.initHandler, rateLimit(s.Logger, initRouteLimit))
+	addRoute(s.Router, "POST", "/dkg", s.dkgHandler, rateLimit(s.Logger, dkgRouteLimit))
+	addRoute(s.Router, "GET", "/health_check", s.healthHandler, rateLimit(s.Logger, healthCheckRouteLimit))
+	addRoute(s.Router, "POST", "/results", s.resultsHandler, rateLimit(s.Logger, resultsRouteLimit))
+	addRoute(s.Router, "POST", "/resign", s.resignHandler, rateLimit(s.Logger, resignRouteLimit))
+	addRoute(s.Router, "POST", "/reshare", s.reshareHandler, rateLimit(s.Logger, reshareRouteLimit))
 }
 
 // Add route with optional middleware

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -24,8 +24,8 @@ import (
 	"github.com/ssvlabs/dkg-spec/eip1271"
 )
 
-const MaxInstances = 1024
-const MaxInstanceTime = 5 * time.Minute
+const MaxInstances = 1024 * 100
+const MaxInstanceTime = 1 * time.Minute
 
 // InstanceID each new DKG ceremony has a unique random ID that we can identify messages and be able to process them in parallel
 type InstanceID [24]byte


### PR DESCRIPTION
Problem:
In InitInstance, any INIT message with a valid signature causes an entry to be added to the s.Instances array. If that array contains 1024 entries not older than 5 minutes, no new DKG can be initiated. Due to Signature verification allows arbitrary public key, anyone with network access can create valid INIT messages, easily denying service to the legitimate initiator.

Solution:
1. increase instances to max 1024 * 100. This will increase hardware requirements but to not critical point as its quite low now.
2. decrease rate limit to init/resign/reshare routes to 100.
3. decrease time to live for instances to 1 minute, as this is more than enough to finish all phases of DKG ceremonies.

In this case, to ddos an attacker needs >= 1024 different IP addresses.