### PR TITLE
Better logs

### DIFF
--- a/cli/initiator/initiator.go
+++ b/cli/initiator/initiator.go
@@ -9,12 +9,12 @@ import (
 	e2m_core "github.com/bloxapp/eth2-key-manager/core"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/spf13/cobra"
-	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	spec "github.com/ssvlabs/dkg-spec"
+	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 const (
@@ -56,7 +56,7 @@ var StartDKG = &cobra.Command{
 		// Load operators TODO: add more sources.
 		operatorIDs, err := cli_utils.StringSliceToUintArray(cli_utils.OperatorIDs)
 		if err != nil {
-			logger.Fatal("😥 Failed to load participants: ", zap.Error(err))
+			logger.Fatal("😥 Failed to load operator IDs: ", zap.Error(err))
 		}
 		opMap, err := cli_utils.LoadOperators(logger)
 		if err != nil {

--- a/cli/initiator/reshare.go
+++ b/cli/initiator/reshare.go
@@ -8,12 +8,12 @@ import (
 
 	e2m_core "github.com/bloxapp/eth2-key-manager/core"
 	"github.com/spf13/cobra"
-	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	spec "github.com/ssvlabs/dkg-spec"
+	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 func init() {
@@ -147,11 +147,11 @@ var StartReshare = &cobra.Command{
 		}
 		oldOperatorIDs, err := cli_utils.StringSliceToUintArray(cli_utils.OperatorIDs)
 		if err != nil {
-			logger.Fatal("😥 Failed to load participants: ", zap.Error(err))
+			logger.Fatal("😥 Failed to load old operator IDs: ", zap.Error(err))
 		}
 		newOperatorIDs, err := cli_utils.StringSliceToUintArray(cli_utils.NewOperatorIDs)
 		if err != nil {
-			logger.Fatal("😥 Failed to load new participants: ", zap.Error(err))
+			logger.Fatal("😥 Failed to load new operator IDs: ", zap.Error(err))
 		}
 		// create a new ID for resharing
 		id := spec.NewID()

--- a/cli/initiator/resigning.go
+++ b/cli/initiator/resigning.go
@@ -8,12 +8,12 @@ import (
 
 	e2m_core "github.com/bloxapp/eth2-key-manager/core"
 	"github.com/spf13/cobra"
-	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	spec "github.com/ssvlabs/dkg-spec"
+	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 func init() {
@@ -141,7 +141,7 @@ var StartResigning = &cobra.Command{
 		}
 		operatorIDs, err := cli_utils.StringSliceToUintArray(cli_utils.OperatorIDs)
 		if err != nil {
-			logger.Fatal("😥 Failed to load participants: ", zap.Error(err))
+			logger.Fatal("😥 Failed to load operator IDs: ", zap.Error(err))
 		}
 		ethNetwork := e2m_core.NetworkFromString(cli_utils.Network)
 		if ethNetwork == "" {

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -402,7 +402,7 @@ func BindInitFlags(cmd *cobra.Command) error {
 	var err error
 	WithdrawAddress, err = utils.HexToAddress(withdrawAddr)
 	if err != nil {
-		return fmt.Errorf("😥 Failed to parse withdraw address: %s", err.Error())
+		return fmt.Errorf("😥 Failed to parse withdraw address: %w", err)
 	}
 	Network = viper.GetString("network")
 	if Network == "" {
@@ -506,7 +506,7 @@ func BindGenerateResignMsgFlags(cmd *cobra.Command) error {
 	var err error
 	WithdrawAddress, err = utils.HexToAddress(withdrawAddr)
 	if err != nil {
-		return fmt.Errorf("😥 Failed to parse withdraw address: %s", err.Error())
+		return fmt.Errorf("😥 Failed to parse withdraw address: %w", err)
 	}
 	Network = viper.GetString("network")
 	if Network == "" {
@@ -617,7 +617,7 @@ func BindGenerateReshareMsgFlags(cmd *cobra.Command) error {
 	var err error
 	WithdrawAddress, err = utils.HexToAddress(withdrawAddr)
 	if err != nil {
-		return fmt.Errorf("😥 Failed to parse withdraw address: %s", err.Error())
+		return fmt.Errorf("😥 Failed to parse withdraw address: %w", err)
 	}
 	Network = viper.GetString("network")
 	if Network == "" {
@@ -629,7 +629,7 @@ func BindGenerateReshareMsgFlags(cmd *cobra.Command) error {
 	}
 	OwnerAddress, err = utils.HexToAddress(owner)
 	if err != nil {
-		return fmt.Errorf("😥 Failed to parse owner address: %s", err)
+		return fmt.Errorf("😥 Failed to parse owner address: %w", err)
 	}
 	Nonce = viper.GetUint64("nonce")
 	Amount = viper.GetUint64("amount")
@@ -772,7 +772,7 @@ func StringSliceToUintArray(flagdata []string) ([]uint64, error) {
 	for i := 0; i < len(flagdata); i++ {
 		opid, err := strconv.ParseUint(flagdata[i], 10, strconv.IntSize)
 		if err != nil {
-			return nil, fmt.Errorf("😥 cant load operator err: %v , data: %v, ", err, flagdata[i])
+			return nil, fmt.Errorf("err: %w , data: %v, ", err, flagdata[i])
 		}
 		partsarr = append(partsarr, opid)
 	}

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -121,34 +121,34 @@ func SetGlobalLogger(cmd *cobra.Command, name string) (*zap.Logger, error) {
 func OpenPrivateKey(passwordFilePath, privKeyPath string) (*rsa.PrivateKey, error) {
 	// check if a password string a valid path, then read password from the file
 	if _, err := os.Stat(passwordFilePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("😥 Password file doesn`t exist: %s", err)
+		return nil, fmt.Errorf("password file doesn`t exist: %w", err)
 	}
 	encryptedRSAJSON, err := os.ReadFile(filepath.Clean(privKeyPath))
 	if err != nil {
-		return nil, fmt.Errorf("😥 Cant read operator's key file: %s", err)
+		return nil, fmt.Errorf("cant read operator's key file: %w", err)
 	}
 	keyStorePassword, err := os.ReadFile(filepath.Clean(passwordFilePath))
 	if err != nil {
-		return nil, fmt.Errorf("😥 Error reading password file: %s", err)
+		return nil, fmt.Errorf("error reading password file: %w", err)
 	}
 	privateKey, err := crypto.DecryptRSAKeystore(encryptedRSAJSON, string(keyStorePassword))
 	if err != nil {
-		return nil, fmt.Errorf("😥 Error converting pem to priv key: %s", err)
+		return nil, fmt.Errorf("error converting pem to priv key: %w", err)
 	}
 	return privateKey, nil
 }
 
 // ReadOperatorsInfoFile reads operators data from path
 func ReadOperatorsInfoFile(operatorsInfoPath string, logger *zap.Logger) (wire.OperatorsCLI, error) {
-	fmt.Printf("📖 looking operators info 'operators_info.json' file: %s \n", operatorsInfoPath)
+	fmt.Printf("📖 looking operators info JSON file: %s \n", operatorsInfoPath)
 	_, err := os.Stat(operatorsInfoPath)
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("😥 Failed to read operator info file: %s", err)
+		return nil, fmt.Errorf("cant find path to operators info JSON file: %s", err)
 	}
 	logger.Info("📖 reading operators info JSON file")
 	operatorsInfoJSON, err := os.ReadFile(filepath.Clean(operatorsInfoPath))
 	if err != nil {
-		return nil, fmt.Errorf("😥 Failed to read operator info file: %s", err)
+		return nil, fmt.Errorf("failed to read operators info JSON file: %w", err)
 	}
 	var operators wire.OperatorsCLI
 	err = json.Unmarshal(operatorsInfoJSON, &operators)

--- a/cli/verify/verify.go
+++ b/cli/verify/verify.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"os"
 
+	"github.com/aquasecurity/table"
 	"github.com/spf13/cobra"
 
-	"github.com/aquasecurity/table"
 	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
 	"github.com/ssvlabs/ssv-dkg/pkgs/validator"
 )
@@ -32,8 +32,7 @@ var Verify = &cobra.Command{
 			cli_utils.WithdrawAddress,
 		)
 		if err != nil {
-			log.Printf("Failed to validate ceremony directory: %v", err)
-			return err
+			return fmt.Errorf("failed to validate ceremony directory: %w",err)
 		}
 
 		log.Printf("Ceremony is valid.")

--- a/pkgs/board/board.go
+++ b/pkgs/board/board.go
@@ -40,7 +40,7 @@ func (b *Board) PushDeals(bundle *dkg.DealBundle) {
 
 	byts, err := wire2.EncodeDealBundle(bundle)
 	if err != nil {
-		b.logger.Error(err.Error())
+		b.logger.Error("error encoding deal bundle", zap.Error(err))
 		return
 	}
 	msg := &wire2.KyberMessage{
@@ -49,7 +49,7 @@ func (b *Board) PushDeals(bundle *dkg.DealBundle) {
 	}
 
 	if err := b.broadcastF(msg); err != nil {
-		b.logger.Error(err.Error())
+		b.logger.Error("error broadcasting deal bundle", zap.Error(err))
 		return
 	}
 }

--- a/pkgs/crypto/deposit_data.go
+++ b/pkgs/crypto/deposit_data.go
@@ -10,10 +10,10 @@ import (
 	"github.com/bloxapp/eth2-key-manager/core"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hashicorp/go-version"
-	spec "github.com/ssvlabs/dkg-spec"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 
+	spec "github.com/ssvlabs/dkg-spec"
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 func BuildDepositDataCLI(network core.Network, depositData *phase0.DepositData, depositCLIVersion string) (*wire.DepositDataCLI, error) {
@@ -24,12 +24,12 @@ func BuildDepositDataCLI(network core.Network, depositData *phase0.DepositData, 
 	copy(depositMsg.PublicKey[:], depositData.PublicKey[:])
 	depositMsgRoot, err := depositMsg.HashTreeRoot()
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute deposit message root: %v", err)
+		return nil, fmt.Errorf("failed to compute deposit message root: %w", err)
 	}
 
 	depositDataRoot, err := depositData.HashTreeRoot()
 	if err != nil {
-		return nil, fmt.Errorf("failed to compute deposit data root: %v", err)
+		return nil, fmt.Errorf("failed to compute deposit data root: %w", err)
 	}
 
 	// Final checks of prepared deposit data
@@ -63,11 +63,11 @@ func validateDepositDataCLI(d *wire.DepositDataCLI, expectedWithdrawalCredential
 	// Re-encode and re-decode the deposit data json to ensure encoding is valid.
 	b, err := json.Marshal(d)
 	if err != nil {
-		return fmt.Errorf("failed to marshal deposit data json: %v", err)
+		return fmt.Errorf("failed to marshal deposit data json: %w", err)
 	}
 	var depositData wire.DepositDataCLI
 	if err := json.Unmarshal(b, &depositData); err != nil {
-		return fmt.Errorf("failed to unmarshal deposit data json: %v", err)
+		return fmt.Errorf("failed to unmarshal deposit data json: %w", err)
 	}
 	if !reflect.DeepEqual(d, &depositData) {
 		return fmt.Errorf("failed to validate deposit data json")
@@ -76,11 +76,11 @@ func validateDepositDataCLI(d *wire.DepositDataCLI, expectedWithdrawalCredential
 
 	// 1. Validate format
 	if err := validateFieldFormatting(d); err != nil {
-		return fmt.Errorf("failed to validate deposit data json: %v", err)
+		return fmt.Errorf("failed to validate deposit data json: %w", err)
 	}
 	// 2. Verify deposit roots and signature
 	if err := verifyDepositRoots(d); err != nil {
-		return fmt.Errorf("failed to verify deposit roots: %v", err)
+		return fmt.Errorf("failed to verify deposit roots: %w", err)
 	}
 	// 3. Verify withdrawal address
 	if d.WithdrawalCredentials != hex.EncodeToString(expectedWithdrawalCredentials) {
@@ -143,26 +143,26 @@ func validateFieldFormatting(d *wire.DepositDataCLI) error {
 func verifyDepositRoots(d *wire.DepositDataCLI) error {
 	pubKey, err := hex.DecodeString(d.PubKey)
 	if err != nil {
-		return fmt.Errorf("failed to decode public key: %v", err)
+		return fmt.Errorf("failed to decode public key: %w", err)
 	}
 	withdrCreds, err := hex.DecodeString(d.WithdrawalCredentials)
 	if err != nil {
-		return fmt.Errorf("failed to decode withdrawal credentials: %v", err)
+		return fmt.Errorf("failed to decode withdrawal credentials: %w", err)
 	}
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil {
-		return fmt.Errorf("failed to decode signature: %v", err)
+		return fmt.Errorf("failed to decode signature: %w", err)
 	}
 	fork, err := hex.DecodeString(d.ForkVersion)
 	if err != nil {
-		return fmt.Errorf("failed to decode fork version: %v", err)
+		return fmt.Errorf("failed to decode fork version: %w", err)
 	}
 	if len(fork) != 4 {
 		return fmt.Errorf("fork version has wrong length")
 	}
 	network, err := spec_crypto.GetNetworkByFork([4]byte(fork))
 	if err != nil {
-		return fmt.Errorf("failed to get network by fork: %v", err)
+		return fmt.Errorf("failed to get network by fork: %w", err)
 	}
 	depositData := &phase0.DepositData{
 		PublicKey:             phase0.BLSPubKey(pubKey),
@@ -172,7 +172,7 @@ func verifyDepositRoots(d *wire.DepositDataCLI) error {
 	}
 	err = spec_crypto.VerifyDepositData(network, depositData)
 	if err != nil {
-		return fmt.Errorf("failed to verify deposit data: %v", err)
+		return fmt.Errorf("failed to verify deposit data: %w", err)
 	}
 	return nil
 }

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -610,7 +610,7 @@ func (o *LocalOwner) Resign(reqID [24]byte, r *wire.ResignMessage) (*wire.Transp
 func (o *LocalOwner) Reshare(reqID [24]byte, reshare *spec.Reshare, commitsPoints []kyber.Point) (*wire.Transport, error) {
 	// sanity check
 	if o.data != nil {
-		return nil, fmt.Errorf("data already exist at local instance: %w", o.data)
+		return nil, fmt.Errorf("data already exist at local instance: %v", o.data)
 	}
 	o.data = &DKGdata{}
 	var commits []byte

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -318,7 +318,7 @@ func (o *LocalOwner) Init(reqID [24]byte, init *spec.Init) (*wire.Transport, err
 func (o *LocalOwner) processDKG(from uint64, msg *wire.Transport) error {
 	kyberMsg := &wire.KyberMessage{}
 	if err := kyberMsg.UnmarshalSSZ(msg.Data); err != nil {
-		return err
+		return fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 	o.Logger.Debug("operator: received kyber msg", zap.String("type", kyberMsg.Type.String()), zap.Uint64("from", from))
 	switch kyberMsg.Type {
@@ -372,7 +372,7 @@ func (o *LocalOwner) Process(st *wire.SignedTransport, incOperators []*spec.Oper
 	case wire.ExchangeMessageType:
 		exchMsg := &wire.Exchange{}
 		if err := exchMsg.UnmarshalSSZ(st.Message.Data); err != nil {
-			return err
+			return fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
 		if _, ok := o.exchanges[from]; ok {
 			return fmt.Errorf("error at init exchange message processing: %w", ErrAlreadyExists)
@@ -389,7 +389,7 @@ func (o *LocalOwner) Process(st *wire.SignedTransport, incOperators []*spec.Oper
 	case wire.ReshareExchangeMessageType:
 		exchMsg := &wire.Exchange{}
 		if err := exchMsg.UnmarshalSSZ(st.Message.Data); err != nil {
-			return err
+			return fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
 		if _, ok := o.exchanges[from]; ok {
 			return fmt.Errorf("error at reshare exchange message processing: %w, from %d", ErrAlreadyExists, from)
@@ -439,7 +439,7 @@ func (o *LocalOwner) Process(st *wire.SignedTransport, incOperators []*spec.Oper
 	case wire.ReshareKyberMessageType:
 		kyberMsg := &wire.ReshareKyberMessage{}
 		if err := kyberMsg.UnmarshalSSZ(st.Message.Data); err != nil {
-			return err
+			return fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
 		b, err := wire.DecodeDealBundle(kyberMsg.Data, o.Suite.G1().(kyber_dkg.Suite))
 		if err != nil {

--- a/pkgs/dkg/drand.go
+++ b/pkgs/dkg/drand.go
@@ -610,7 +610,7 @@ func (o *LocalOwner) Resign(reqID [24]byte, r *wire.ResignMessage) (*wire.Transp
 func (o *LocalOwner) Reshare(reqID [24]byte, reshare *spec.Reshare, commitsPoints []kyber.Point) (*wire.Transport, error) {
 	// sanity check
 	if o.data != nil {
-		return nil, fmt.Errorf("data already exist at local instance: %v", o.data)
+		return nil, fmt.Errorf("data already exist at local instance: %w", o.data)
 	}
 	o.data = &DKGdata{}
 	var commits []byte

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -149,7 +149,7 @@ func ValidatedOperatorData(ids []uint64, operators wire.OperatorsCLI) ([]*spec.O
 
 		pkBytes, err := spec_crypto.EncodeRSAPublicKey(op.PubKey)
 		if err != nil {
-			return nil, fmt.Errorf("can't encode public key err: %v", err)
+			return nil, fmt.Errorf("can't encode public key err: %w", err)
 		}
 		ops[i] = &spec.Operator{
 			ID:     op.ID,
@@ -570,7 +570,7 @@ func (c *Initiator) processDKGResultResponse(dkgResults []*spec.Result,
 	}
 	depositDataJson, err := crypto.BuildDepositDataCLI(network, depositData, wire.DepositCliVersion)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create deposit data json: %v", err)
+		return nil, nil, fmt.Errorf("failed to create deposit data json: %w", err)
 	}
 	c.Logger.Info("✅ deposit data was successfully reconstructed")
 	keyshares, err := c.generateSSVKeysharesPayload(ops, dkgResults, masterSigOwnerNonce, ownerAddress, nonce)
@@ -775,11 +775,11 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 	}
 	signedPongMsg := &wire.SignedTransport{}
 	if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
-		errmsg, parseErr := wire.ParseAsError(res.Result)
-		if parseErr == nil {
-			return fmt.Errorf("operator returned err: %v", errmsg)
+		errString, err := wire.ParseAsError(res.Result)
+		if err == nil {
+			return fmt.Errorf("cant parse error message: %w", err)
 		}
-		return err
+		return fmt.Errorf("operator returned error: %s", errString)
 	}
 	// Validate that incoming message is an pong message
 	if signedPongMsg.Message.Type != wire.PongMessageType {

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/attestantio/go-eth2-client/spec/phase0"
@@ -896,6 +897,9 @@ func checkThreshold(responses map[uint64][]byte, errs map[uint64]error, oldOpera
 	var finalErr error
 	for _, op := range newOperators {
 		if err, ok := errs[op.ID]; ok {
+			if strings.Contains(err.Error(), "invalid ssz encoding") {
+				err = fmt.Errorf("%w, operator probably of old version 1.*.*, please upgrade", err)
+			}
 			finalErr = errors.Join(finalErr, fmt.Errorf("error: %w", err))
 		}
 	}

--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -775,6 +775,10 @@ func (c *Initiator) processPongMessage(res wire.PongResult) error {
 	}
 	signedPongMsg := &wire.SignedTransport{}
 	if err := signedPongMsg.UnmarshalSSZ(res.Result); err != nil {
+		if strings.Contains(err.Error(), "incorrect offset") {
+			return fmt.Errorf("%w, operator probably of old version, please upgrade", err)
+		}
+		// in case we received error message, try unmarshall
 		errString, err := wire.ParseAsError(res.Result)
 		if err == nil {
 			return fmt.Errorf("cant parse error message: %w", err)

--- a/pkgs/initiator/initiator_test.go
+++ b/pkgs/initiator/initiator_test.go
@@ -14,17 +14,17 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/herumi/bls-eth-go-binary/bls"
-	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
-	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
-	"github.com/ssvlabs/ssv-dkg/pkgs/utils/test_utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/validator"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	spec "github.com/ssvlabs/dkg-spec"
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
 	"github.com/ssvlabs/dkg-spec/testing/stubs"
+	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/initiator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/utils/test_utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/validator"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 var (
@@ -285,7 +285,7 @@ func TestValidateDKGParams(t *testing.T) {
 					t.Errorf("expected error message %q but got %q", tt.errMsg, err.Error())
 				}
 			case err != nil:
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("unexpected error: %w", err)
 			default:
 				// verify list is ok
 				need := len(tt.ids)

--- a/pkgs/initiator/initiator_test.go
+++ b/pkgs/initiator/initiator_test.go
@@ -285,7 +285,7 @@ func TestValidateDKGParams(t *testing.T) {
 					t.Errorf("expected error message %q but got %q", tt.errMsg, err.Error())
 				}
 			case err != nil:
-				t.Errorf("unexpected error: %w", err)
+				t.Errorf("unexpected error: %s", err)
 			default:
 				// verify list is ok
 				need := len(tt.ids)

--- a/pkgs/initiator/requests.go
+++ b/pkgs/initiator/requests.go
@@ -33,11 +33,11 @@ func (c *Initiator) SendAndCollect(op wire.OperatorCLI, method string, data []by
 	}
 	c.Logger.Debug("operator responded", zap.Uint64("operator", op.ID), zap.String("IP", op.Addr), zap.String("method", method), zap.Int("status", res.StatusCode))
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		errmsg, parseErr := wire.ParseAsError(resdata)
-		if parseErr == nil {
-			return nil, fmt.Errorf("%v", errmsg)
+		errString, err := wire.ParseAsError(resdata)
+		if err != nil {
+			return nil, fmt.Errorf("cant parse error message: %w", err)
 		}
-		return nil, fmt.Errorf("operator %d failed with: %w, probably of old version 1.*.*, please upgrade", op.ID, errors.New(string(resdata)))
+		return nil, fmt.Errorf("operator %d failed with: probably of old version, please upgrade %w", op.ID, errors.New(errString))
 	}
 	return resdata, nil
 }

--- a/pkgs/operator/handlers.go
+++ b/pkgs/operator/handlers.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
 	"github.com/ssvlabs/ssv-dkg/pkgs/utils"
 	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
-	"go.uber.org/zap"
 )
 
 func (s *Server) resultsHandler(writer http.ResponseWriter, request *http.Request) {
@@ -20,7 +21,7 @@ func (s *Server) resultsHandler(writer http.ResponseWriter, request *http.Reques
 	}
 	signedResultMsg := &wire.SignedTransport{}
 	if err := signedResultMsg.UnmarshalSSZ(rawdata); err != nil {
-		utils.WriteErrorResponse(s.Logger, writer, err, http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err), http.StatusBadRequest)
 		return
 	}
 
@@ -128,7 +129,7 @@ func (s *Server) signedReshareHandler(writer http.ResponseWriter, request *http.
 	signedReshareMsg, err := processIncomingRequest(s.Logger, writer, request, wire.SignedReshareMessageType, s.State.OperatorID)
 	if err != nil {
 		s.Logger.Error("Error processing incoming reshare message", zap.Error(err))
-		utils.WriteErrorResponse(s.Logger, writer, err, http.StatusBadRequest)
+		utils.WriteErrorResponse(s.Logger, writer, fmt.Errorf("operator %d, err: %w", s.State.OperatorID, err), http.StatusBadRequest)
 		return
 	}
 

--- a/pkgs/operator/instance.go
+++ b/pkgs/operator/instance.go
@@ -4,12 +4,12 @@ import (
 	"crypto/rsa"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	spec "github.com/ssvlabs/dkg-spec"
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
 	"github.com/ssvlabs/ssv-dkg/pkgs/dkg"
 	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
-
-	"go.uber.org/zap"
 )
 
 // Instance interface to process messages at DKG instances incoming from initiator
@@ -43,14 +43,14 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 	for _, transportMsg := range msg.Messages {
 		msgBytes, err := transportMsg.MarshalSSZ()
 		if err != nil {
-			return nil, fmt.Errorf("process message: failed to marshal message: %s", err.Error())
+			return nil, fmt.Errorf("process message: failed to ssz marshal message: %w", err)
 		}
 		multipleMsgsBytes = append(multipleMsgsBytes, msgBytes...)
 	}
 	// Verify initiator signature
 	err := iw.VerifyInitiatorMessage(multipleMsgsBytes, msg.Signature)
 	if err != nil {
-		return nil, fmt.Errorf("process message: failed to verify initiator signature: %s", err.Error())
+		return nil, fmt.Errorf("process message: failed to verify initiator signature: %w", err)
 	}
 
 	// check that we received enough messages from other operator participants
@@ -69,7 +69,7 @@ func (iw *instWrapper) ProcessMessages(msg *wire.MultipleSignedTransports) ([]by
 	for _, ts := range msg.Messages {
 		err = iw.Process(ts, incOperators)
 		if err != nil {
-			return nil, fmt.Errorf("process message: failed to process dkg message: %s", err.Error())
+			return nil, fmt.Errorf("process message: failed to process dkg message: %w", err)
 		}
 	}
 	return <-iw.respChan, nil

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -96,15 +96,15 @@ func (s *Switch) InitInstance(reqID [24]byte, initMsg *wire.Transport, initiator
 	// Check that incoming message signature is valid
 	initiatorPubKey, err := spec_crypto.ParseRSAPublicKey(initiatorPub)
 	if err != nil {
-		return nil, fmt.Errorf("init: failed parse initiator public key: %s", err.Error())
+		return nil, fmt.Errorf("init: failed parse initiator public key: %w", err)
 	}
 	marshalledWireMsg, err := initMsg.MarshalSSZ()
 	if err != nil {
-		return nil, fmt.Errorf("init: failed to marshal transport message: %s", err.Error())
+		return nil, fmt.Errorf("init: failed to marshal transport message: %w", err)
 	}
 	err = spec_crypto.VerifyRSA(initiatorPubKey, marshalledWireMsg, initiatorSignature)
 	if err != nil {
-		return nil, fmt.Errorf("init: initiator signature isn't valid: %s", err.Error())
+		return nil, fmt.Errorf("init: initiator signature isn't valid: %w", err)
 	}
 	s.Logger.Info("✅ init message signature is successfully verified", zap.String("from initiator", fmt.Sprintf("%x", initiatorPubKey.N.Bytes())))
 	if err := s.validateInstances(reqID); err != nil {
@@ -112,7 +112,7 @@ func (s *Switch) InitInstance(reqID [24]byte, initMsg *wire.Transport, initiator
 	}
 	inst, resp, err := s.CreateInstance(reqID, init.Operators, init, initiatorPubKey)
 	if err != nil {
-		return nil, fmt.Errorf("init: failed to create instance: %s", err.Error())
+		return nil, fmt.Errorf("init: failed to create instance: %w", err)
 	}
 	s.Mtx.Lock()
 	s.Instances[reqID] = inst
@@ -143,15 +143,15 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 	// Check that incoming message signature is valid
 	initiatorPubKey, err := spec_crypto.ParseRSAPublicKey(initiatorPub)
 	if err != nil {
-		return nil, fmt.Errorf("%s: failed to parse initiator public key: %s", operationType, err.Error())
+		return nil, fmt.Errorf("%s: failed to parse initiator public key: %w", operationType, err)
 	}
 	marshalledWireMsg, err := transportMsg.MarshalSSZ()
 	if err != nil {
-		return nil, fmt.Errorf("%s: failed to marshal transport message: %s", operationType, err.Error())
+		return nil, fmt.Errorf("%s: failed to marshal transport message: %w", operationType, err)
 	}
 	err = spec_crypto.VerifyRSA(initiatorPubKey, marshalledWireMsg, initiatorSignature)
 	if err != nil {
-		return nil, fmt.Errorf("%s: initiator signature isn't valid: %s", operationType, err.Error())
+		return nil, fmt.Errorf("%s: initiator signature isn't valid: %w", operationType, err)
 	}
 
 	s.Logger.Info(fmt.Sprintf("🚀 Handling %s operation", operationType))

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -88,7 +88,7 @@ func (s *Switch) InitInstance(reqID [24]byte, initMsg *wire.Transport, initiator
 	s.Logger.Info("🚀 Initializing Init instance")
 	init := &spec.Init{}
 	if err := init.UnmarshalSSZ(initMsg.Data); err != nil {
-		return nil, fmt.Errorf("init: failed to unmarshal init message: %s", err.Error())
+		return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 	if err := spec.ValidateInitMessage(init); err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 	case "resign":
 		signedResign := &wire.SignedResign{}
 		if err := signedResign.UnmarshalSSZ(transportMsg.Data); err != nil {
-			return nil, fmt.Errorf("%s: failed to unmarshal signed resign message: %s", operationType, err.Error())
+			return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
 		allOps = signedResign.Messages[0].Operators
 
@@ -203,7 +203,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 	case "reshare":
 		signedReshare := &wire.SignedReshare{}
 		if err := signedReshare.UnmarshalSSZ(transportMsg.Data); err != nil {
-			return nil, fmt.Errorf("%s: failed to unmarshal signed reshare message: %s", operationType, err.Error())
+			return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 		}
 		if len(signedReshare.Messages) == 0 {
 			return nil, fmt.Errorf("%s: no reshare messages", operationType)

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-chi/chi/v5"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 // request limits
@@ -81,11 +81,11 @@ func processIncomingRequest(logger *zap.Logger, writer http.ResponseWriter, requ
 	}
 	signedMsg := &wire.SignedTransport{}
 	if err := signedMsg.UnmarshalSSZ(rawdata); err != nil {
-		return nil, fmt.Errorf("operator %d, failed to unmarshal SSZ, err: %v", operatorID, err)
+		return nil, fmt.Errorf("operator %d, failed to unmarshal SSZ, err: probably an upgrade to latest version needed: %w", operatorID, err)
 	}
 	// Validate that incoming message has requested type
 	if signedMsg.Message.Type != reqMessageType {
-		return nil, fmt.Errorf("operator %d, received wrong message typec", operatorID)
+		return nil, fmt.Errorf("operator %d, received wrong message type: want %s, got: %s", reqMessageType, signedMsg.Message.Type, operatorID)
 	}
 	return signedMsg, nil
 }

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -77,7 +77,7 @@ func (s *Server) Start(port uint16, cert, key string) error {
 func processIncomingRequest(logger *zap.Logger, writer http.ResponseWriter, request *http.Request, reqMessageType wire.TransportType, operatorID uint64) (*wire.SignedTransport, error) {
 	rawdata, err := io.ReadAll(request.Body)
 	if err != nil {
-		return nil, fmt.Errorf("operator %d, failed to read request body, err: %v", operatorID, err)
+		return nil, fmt.Errorf("operator %d, failed to read request body, err: %w", operatorID, err)
 	}
 	signedMsg := &wire.SignedTransport{}
 	if err := signedMsg.UnmarshalSSZ(rawdata); err != nil {

--- a/pkgs/operator/operator.go
+++ b/pkgs/operator/operator.go
@@ -85,7 +85,7 @@ func processIncomingRequest(logger *zap.Logger, writer http.ResponseWriter, requ
 	}
 	// Validate that incoming message has requested type
 	if signedMsg.Message.Type != reqMessageType {
-		return nil, fmt.Errorf("operator %d, received wrong message type: want %s, got: %s", reqMessageType, signedMsg.Message.Type, operatorID)
+		return nil, fmt.Errorf("operator %d, received wrong message type: want %s, got: %s", operatorID, reqMessageType, signedMsg.Message.Type)
 	}
 	return signedMsg, nil
 }

--- a/pkgs/operator/router.go
+++ b/pkgs/operator/router.go
@@ -41,7 +41,7 @@ func rateLimit(logger *zap.Logger, limit int) func(http.Handler) http.Handler {
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, err := w.Write([]byte(ErrTooManyRouteRequests))
 			if err != nil {
-				logger.Error("error writing rate limit response: " + err.Error())
+				logger.Error("error writing rate limit response", zap.Error(err))
 			}
 		}),
 	)

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -14,15 +14,15 @@ import (
 	kyber_bls12381 "github.com/drand/kyber-bls12381"
 	kyber_dkg "github.com/drand/kyber/share/dkg"
 	eth_common "github.com/ethereum/go-ethereum/common"
-	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
-	"github.com/ssvlabs/ssv-dkg/pkgs/utils"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	spec "github.com/ssvlabs/dkg-spec"
 	spec_crypto "github.com/ssvlabs/dkg-spec/crypto"
 	"github.com/ssvlabs/dkg-spec/eip1271"
+	cli_utils "github.com/ssvlabs/ssv-dkg/cli/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/crypto"
+	"github.com/ssvlabs/ssv-dkg/pkgs/utils"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 const MaxInstances = 1024 * 100
@@ -117,7 +117,7 @@ func (s *Switch) ProcessMessage(dkgMsg []byte) ([]byte, error) {
 	st := &wire.MultipleSignedTransports{}
 	err := st.UnmarshalSSZ(dkgMsg)
 	if err != nil {
-		return nil, fmt.Errorf("process message: failed to unmarshal dkg message: %s", err.Error())
+		return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 
 	id := InstanceID(st.Identifier)
@@ -182,7 +182,7 @@ func (s *Switch) SaveResultData(incMsg *wire.SignedTransport, outputPath string)
 	resData := &wire.ResultData{}
 	err := resData.UnmarshalSSZ(incMsg.Message.Data)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 	_, err = s.VerifyIncomingMessage(incMsg)
 	if err != nil {
@@ -239,7 +239,7 @@ func (s *Switch) VerifyIncomingMessage(incMsg *wire.SignedTransport) (uint64, er
 
 	resData := &wire.ResultData{}
 	if err := resData.UnmarshalSSZ(incMsg.Message.Data); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 	s.Mtx.RLock()
 	inst, ok := s.Instances[resData.Identifier]

--- a/pkgs/operator/state.go
+++ b/pkgs/operator/state.go
@@ -212,7 +212,7 @@ func (s *Switch) SaveResultData(incMsg *wire.SignedTransport, outputPath string)
 	proofsArr := [][]*wire.SignedProof{proof}
 	withdrawCreds, err := hex.DecodeString(depJson.WithdrawalCredentials)
 	if err != nil {
-		return fmt.Errorf("failed to decode withdrawal credentials: %s", err.Error())
+		return fmt.Errorf("failed to decode withdrawal credentials: %w", err)
 	}
 	withdrawPrefix, withdrawAddress := crypto.ParseWithdrawalCredentials(withdrawCreds)
 	if withdrawPrefix != spec_crypto.ETH1WithdrawalPrefixByte {

--- a/pkgs/utils/utils.go
+++ b/pkgs/utils/utils.go
@@ -14,11 +14,11 @@ import (
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 	"go.uber.org/zap"
 
 	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	spec "github.com/ssvlabs/dkg-spec"
+	"github.com/ssvlabs/ssv-dkg/pkgs/wire"
 )
 
 var ErrMissingInstance = errors.New("got message to instance that I don't have, send Init first")
@@ -86,7 +86,6 @@ func GetThreshold[S ~[]E, E any](ids S) int {
 }
 
 func WriteErrorResponse(logger *zap.Logger, writer http.ResponseWriter, err error, statusCode int) {
-	logger.Error("request error: " + err.Error())
 	writer.WriteHeader(statusCode)
 	presentedErr := err
 
@@ -98,7 +97,7 @@ func WriteErrorResponse(logger *zap.Logger, writer http.ResponseWriter, err erro
 
 	_, writeErr := writer.Write(wire.MakeErr(presentedErr))
 	if writeErr != nil {
-		logger.Error("error writing error response: " + writeErr.Error())
+		logger.Error("error writing error response", zap.Error(writeErr))
 	}
 }
 

--- a/pkgs/wire/errors.go
+++ b/pkgs/wire/errors.go
@@ -1,5 +1,11 @@
 package wire
 
+import "errors"
+
+var (
+	ErrSSZEncoding = errors.New("failed to ssz unmarshal message: probably an upgrade to latest version needed")
+)
+
 // MakeErr creates an error message
 func MakeErr(err error) (reterr []byte) {
 	rawerr := &ErrSSZ{Error: []byte(err.Error())}

--- a/pkgs/wire/errors.go
+++ b/pkgs/wire/errors.go
@@ -1,6 +1,8 @@
 package wire
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	ErrSSZEncoding = errors.New("failed to ssz unmarshal message: probably an upgrade to latest version needed")
@@ -11,7 +13,9 @@ func MakeErr(err error) (reterr []byte) {
 	rawerr := &ErrSSZ{Error: []byte(err.Error())}
 	reterr, err = rawerr.MarshalSSZ()
 	if err != nil {
-		panic(err)
+		rawerr = &ErrSSZ{Error: []byte("something went really wrong, failed to ssz encode error. Please check.")}
+		reterr, _ = rawerr.MarshalSSZ()
+		return reterr
 	}
 	return reterr
 }

--- a/pkgs/wire/types_json.go
+++ b/pkgs/wire/types_json.go
@@ -46,7 +46,7 @@ func (p *Proof) MarshalJSON() ([]byte, error) {
 func (p *Proof) UnmarshalJSON(data []byte) error {
 	var proof proofJSON
 	if err := json.Unmarshal(data, &proof); err != nil {
-		return fmt.Errorf("failed to unmarshal to proofJSON %s", err.Error())
+		return fmt.Errorf("failed to unmarshal to proofJSON %w", err)
 	}
 	if len(proof.Owner) != 40 {
 		return fmt.Errorf("invalid owner length")
@@ -115,7 +115,7 @@ func (sp *SignedProof) UnmarshalJSON(data []byte) error {
 	sp.Proof = p
 	sig, err := hex.DecodeString(signedProof.Signature)
 	if err != nil {
-		return fmt.Errorf("cant decode hex at proof signature %s", err.Error())
+		return fmt.Errorf("cant decode hex at proof signature %w", err)
 	}
 	sp.Signature = sig
 	return err
@@ -228,15 +228,15 @@ func (o *OperatorCLI) MarshalJSON() ([]byte, error) {
 func (o *OperatorCLI) UnmarshalJSON(data []byte) error {
 	var op operatorCLIJSON
 	if err := json.Unmarshal(data, &op); err != nil {
-		return fmt.Errorf("failed to unmarshal operator: %s", err.Error())
+		return fmt.Errorf("failed to unmarshal operator: %w", err)
 	}
 	_, err := url.ParseRequestURI(op.Addr)
 	if err != nil {
-		return fmt.Errorf("invalid operator %d URL %s", op.ID, err.Error())
+		return fmt.Errorf("invalid operator %d URL %w", op.ID, err)
 	}
 	pk, err := ParseRSAPublicKey([]byte(op.PubKey))
 	if err != nil {
-		return fmt.Errorf("invalid operator %d public key %s", op.ID, err.Error())
+		return fmt.Errorf("invalid operator %d public key %w", op.ID, err)
 	}
 	*o = OperatorCLI{
 		Addr:   strings.TrimRight(op.Addr, "/"),

--- a/pkgs/wire/utils.go
+++ b/pkgs/wire/utils.go
@@ -1,16 +1,15 @@
 package wire
 
 import (
-	"errors"
 	"fmt"
 )
 
 // parseAsError parses the error from an operator
-func ParseAsError(msg []byte) (parsedErr, err error) {
+func ParseAsError(msg []byte) (string, error) {
 	sszerr := &ErrSSZ{}
-	err = sszerr.UnmarshalSSZ(msg)
+	err := sszerr.UnmarshalSSZ(msg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
+		return "", fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
-	return errors.New(string(sszerr.Error)), nil
+	return string(sszerr.Error), nil
 }

--- a/pkgs/wire/utils.go
+++ b/pkgs/wire/utils.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"errors"
+	"fmt"
 )
 
 // parseAsError parses the error from an operator
@@ -9,7 +10,7 @@ func ParseAsError(msg []byte) (parsedErr, err error) {
 	sszerr := &ErrSSZ{}
 	err = sszerr.UnmarshalSSZ(msg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to ssz unmarshal message: probably an upgrade to latest version needed: %w", err)
 	}
 	return errors.New(string(sszerr.Error)), nil
 }


### PR DESCRIPTION
Fix for https://github.com/ssvlabs/ssv-dkg/issues/109 and https://github.com/ssvlabs/ssv-dkg/issues/106

Old version 0.0.1 and 1.0.1 reply with error `incorrect offset` as they cant `ssz` unmarshal messages structured differently.
In case of `ping` to older versions even dont have `health_check` route, so they reply 404