### PR TITLE
Fix for 5.10 reshare denial of service via predicable instance i ds

### DIFF
--- a/pkgs/initiator/initiator.go
+++ b/pkgs/initiator/initiator.go
@@ -215,11 +215,14 @@ func (c *Initiator) ResignMessageFlowHandling(signedResign *wire.SignedResign, i
 	// reqIDtracker is used to track if all ceremony are in the responses in the expected order
 	reqIDs := make([][24]byte, 0)
 	for _, msg := range signedResign.Messages {
-		reqID, err := utils.GetReqIDfromMsg(msg)
+		hash, err := utils.GetReqIDfromMsg(msg)
 		if err != nil {
 			return nil, err
 		}
-		reqIDs = append(reqIDs, reqID)
+		msgID := [24]byte{}
+		copy(msgID[:12], id[:12])
+		copy(msgID[12:24], hash[:12])
+		reqIDs = append(reqIDs, msgID)
 	}
 	resignResult, errs, err := c.SendResignMsg(id, signedResign, operators)
 	if err != nil {
@@ -270,11 +273,14 @@ func (c *Initiator) ReshareMessageFlowHandling(id [24]byte, signedReshare *wire.
 	// reqIDtracker is used to track if all ceremony are in the responses in the expected order
 	reqIDs := make([][24]byte, 0)
 	for _, msg := range signedReshare.Messages {
-		reqID, err := utils.GetReqIDfromMsg(msg)
+		hash, err := utils.GetReqIDfromMsg(msg)
 		if err != nil {
 			return nil, err
 		}
-		reqIDs = append(reqIDs, reqID)
+		msgID := [24]byte{}
+		copy(msgID[:12], id[:12])
+		copy(msgID[12:24], hash[:12])
+		reqIDs = append(reqIDs, msgID)
 	}
 	c.Logger.Info("sending signed reshare message to all operators")
 	var errs map[uint64]error
@@ -394,11 +400,14 @@ func (c *Initiator) StartResigning(id [24]byte, signedResign *wire.SignedResign)
 	}
 	resignIDMap := make(map[[24]byte]*spec.Resign)
 	for _, msg := range signedResign.Messages {
-		reqID, err := utils.GetReqIDfromMsg(msg)
+		hash, err := utils.GetReqIDfromMsg(msg)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		resignIDMap[reqID] = msg.Resign
+		msgID := [24]byte{}
+		copy(msgID[:12], id[:12])
+		copy(msgID[12:24], hash[:12])
+		resignIDMap[msgID] = msg.Resign
 	}
 	var operatorIDs []uint64
 	for _, op := range signedResign.Messages[0].Operators {
@@ -511,11 +520,14 @@ func (c *Initiator) StartResharing(id [24]byte, signedReshare *wire.SignedReshar
 	}
 	reshareIDMap := make(map[[24]byte]*spec.Reshare)
 	for _, msg := range signedReshare.Messages {
-		reqID, err := utils.GetReqIDfromMsg(msg)
+		hash, err := utils.GetReqIDfromMsg(msg)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		reshareIDMap[reqID] = msg.Reshare
+		msgID := [24]byte{}
+		copy(msgID[:12], id[:12])
+		copy(msgID[12:24], hash[:12])
+		reshareIDMap[msgID] = msg.Reshare
 	}
 	oldOperatorIDs := make([]uint64, 0)
 	for _, op := range signedReshare.Messages[0].Reshare.OldOperators {

--- a/pkgs/operator/instances_manager.go
+++ b/pkgs/operator/instances_manager.go
@@ -195,7 +195,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 		resps := [][]byte{}
 		// Run all resign/reshare ceremonies
 		for _, instance := range signedResign.Messages {
-			resp, err := s.runInstance(instance, allOps, initiatorPubKey, operationType)
+			resp, err := s.runInstance(reqID, instance, allOps, initiatorPubKey, operationType)
 			if err != nil {
 				return nil, fmt.Errorf("%s: failed to run instance: %w", operationType, err)
 			}
@@ -246,7 +246,7 @@ func (s *Switch) HandleInstanceOperation(reqID [24]byte, transportMsg *wire.Tran
 		resps := [][]byte{}
 		// Run all resign/reshare ceremonies
 		for _, instance := range signedReshare.Messages {
-			resp, err := s.runInstance(instance, allOps, initiatorPubKey, operationType)
+			resp, err := s.runInstance(reqID, instance, allOps, initiatorPubKey, operationType)
 			if err != nil {
 				return nil, fmt.Errorf("%s: failed to run instance: %w", operationType, err)
 			}
@@ -296,23 +296,26 @@ func (s *Switch) validateInstances(reqID InstanceID) error {
 	return nil
 }
 
-func (s *Switch) runInstance(instance interface{}, allOps []*spec.Operator, initiatorPubKey *rsa.PublicKey, operationType string) ([]byte, error) {
-	reqID, err := utils.GetReqIDfromMsg(instance)
+func (s *Switch) runInstance(reqID [24]byte, instance interface{}, allOps []*spec.Operator, initiatorPubKey *rsa.PublicKey, operationType string) ([]byte, error) {
+	instanceID := [24]byte{}
+	hash, err := utils.GetReqIDfromMsg(instance)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.validateInstances(reqID); err != nil {
+	copy(instanceID[:12], reqID[:12])
+	copy(instanceID[12:24], hash[:12])
+	if err := s.validateInstances(instanceID); err != nil {
 		return nil, err
 	}
 
-	inst, resp, err := s.CreateInstance(reqID, allOps, instance, initiatorPubKey)
+	inst, resp, err := s.CreateInstance(instanceID, allOps, instance, initiatorPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to create instance: %w", operationType, err)
 	}
 
 	s.Mtx.Lock()
-	s.Instances[reqID] = inst
-	s.InstanceInitTime[reqID] = time.Now()
+	s.Instances[instanceID] = inst
+	s.InstanceInitTime[instanceID] = time.Now()
 	s.Mtx.Unlock()
 
 	return resp, nil


### PR DESCRIPTION
Description:

A reshare message can initiate multiple DKG instances. The request IDs for those DKG instances are
chosen deterministically by hashing the reshare message. Then, the DKG instances are performed by
the initiator in sequence. Given that instances become stale after one minute, it is possible to evict later
reshare instances from the buffer by reuse their instance ID or spamming the buffer. This will prevent the
legitimate initiator from finishing.

Solution:

*  add entropy to instance ID by combining 12 bytes of random UUID and hash of reshare message.