### PR TITLE
Complete fix of 5.4 Reshare Denial-of-Service via Predicable Instance IDs

### DIFF
--- a/pkgs/utils/utils.go
+++ b/pkgs/utils/utils.go
@@ -264,15 +264,16 @@ func GetMessageHash(msg interface{}) ([32]byte, error) {
 	return hash, nil
 }
 
-func GetReqIDfromMsg(instance interface{}, id [24]byte) ([24]byte, error) {
+func GetInstanceIDfromMsg(instance interface{}, id [24]byte, initiatorPub []byte) ([24]byte, error) {
 	// make a unique ID for each reshare using the instance hash
 	reqID := [24]byte{}
 	instanceHash, err := GetMessageHash(instance)
 	if err != nil {
 		return reqID, fmt.Errorf("failed to get reqID: %w", err)
 	}
-	copy(reqID[:12], id[:12])
-	copy(reqID[12:24], instanceHash[:12])
+	copy(reqID[:8], eth_crypto.Keccak256(initiatorPub)[:8])
+	copy(reqID[8:16], instanceHash[:8])
+	copy(reqID[16:24], id[:8])
 	return reqID, nil
 }
 


### PR DESCRIPTION
* compute instance ID at operators as `[24]byte = [8]byte(keccak(initiator pub)) + [8]byte(keccak(message)) + [8]byte(uuid entropy)

This effectively prevents malicious actors to create same instance IDs at operators for DoS as [8]byte of `keccak(initiator pub)` ensures that only initiator can use one unique ID as we verify his signature and ensure that pub key belongs to initiator.